### PR TITLE
Fix XSS risk in ebook rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -1075,12 +1075,13 @@
 
                 // Content Pages
                 pagesData.forEach((page, index) => {
+                    const sanitizedText = escapeHtml(page.text);
                     bookHtml += `<div id="page-${index + 1}" class="page grid-cols-1 md:grid-cols-2 gap-4 bg-white p-4 rounded-lg border">
                         <div class="flex items-center justify-center bg-gray-100 rounded-md overflow-hidden border">
                            <img src="${page.imageUrl}" alt="Ilustración para el cuento" class="w-full h-full object-cover" onerror="this.src='https://placehold.co/400x400/e0e7ff/3730a3?text=🎨'">
                         </div>
                         <div class="flex items-center p-4 md:p-6 bg-gray-50 rounded-md border">
-                            <p class="text-gray-700 leading-relaxed text-base md:text-lg">${page.text}</p>
+                            <p class="text-gray-700 leading-relaxed text-base md:text-lg">${sanitizedText}</p>
                         </div>
                     </div>`;
                 });
@@ -1290,6 +1291,12 @@
             }
 
             // --- Utility Functions ---
+            function escapeHtml(str) {
+                const div = document.createElement('div');
+                div.textContent = str;
+                return div.innerHTML;
+            }
+
             function readFileAsBase64(file) {
                 return new Promise((resolve, reject) => {
                     const reader = new FileReader();


### PR DESCRIPTION
## Summary
- sanitize page text before injecting into the DOM
- add helper `escapeHtml` to escape user provided text

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_688d3898201483308548b53b1312a79d