### PR TITLE
Document DELETE stories route

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ dependencias externas.
 node server.js
 ```
 
-El servidor servirá la página web y expondrá dos rutas:
+El servidor servirá la página web y expondrá tres rutas:
 
 - `GET /api/stories?user=<email>`: devuelve los cuentos guardados para ese
   usuario.
 - `POST /api/stories`: guarda un cuento. El cuerpo debe contener `{ user,
   story }`.
+- `DELETE /api/stories?user=<email>`: elimina todos los cuentos de ese
+  usuario.
 
 Los datos se guardan en el archivo `stories.json`.
 


### PR DESCRIPTION
## Summary
- document the DELETE /api/stories route in README

## Testing
- `grep -n "DELETE" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_688d389d8cc8833090ec7ee22e9aff1c